### PR TITLE
Allow ogVideo to be either from og:video or og:video:url

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,8 +106,8 @@ var fieldsArray = [
 	},
 	{
 		multiple: true,
-		property: 'og:video:url',
-		fieldName: 'ogVideoURL'
+		property: 'og:video:url', // An alternative to 'og:video'
+		fieldName: 'ogVideo'
 	},
 	{
 		multiple: true,
@@ -311,7 +311,7 @@ exports.getOG = function (options, callback) {
 
 			/* Combine video/width/height/type
 				and sort for priority */
-			var ogVideos = _.zip(ogObject.ogVideoURL,
+			var ogVideos = _.zip(ogObject.ogVideo,
 					ogObject.ogVideoWidth,
 					ogObject.ogVideoHeight,
 					ogObject.ogVideoType)

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -65,10 +65,13 @@ var options12 = {
 		'url': 'this is a testt'
 	};
 
-// test video
+// test videos
 var optionsYoutube = {
 		'url': "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-	};
+	},
+    optionsTwitch = {
+      'url': "http://www.twitch.tv/valinor000/v/39898875"
+    };
 
 
 describe('GET OG', function () {
@@ -217,9 +220,18 @@ describe('GET OG', function () {
 			expect(result.data.ogUrl).to.be('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 			expect(result.data.ogDescription).to.be('Music video by Rick Astley performing Never Gonna Give You Up. YouTube view counts pre-VEVO: 2,573,462 (C) 1987 PWL');
 			expect(result.data.ogImage.url).to.be('https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg');
+			expect(result.data.ogVideo.url).to.be('https://www.youtube.com/embed/dQw4w9WgXcQ');
 			expect(result.data.ogVideo.type).to.be('text/html');
 			expect(result.data.ogVideo.width).to.be('480');
 			expect(result.data.ogVideo.height).to.be('360');
+			done();
+		});
+        });
+        it('Test Twitch.tv Video - Should Return correct Open Graph Info', function (done) {
+		app(optionsTwitch, function (err, result) {
+			expect(err).to.be(false);
+			expect(result.success).to.be(true);
+			expect(result.data.ogVideo.url).to.be('http://www-cdn.jtvnw.net/swflibs/TwitchPlayer.swf?channel=valinor000&playerType=facebook');
 			done();
 		});
         });


### PR DESCRIPTION
Looks like I jumped the gun on that last PR. It looks like both `og:video` and `og:video:url` are valid tags for the URL of the video, this PR should handle both cases.