### PR TITLE
Report error on 404 response code

### DIFF
--- a/app.js
+++ b/app.js
@@ -264,6 +264,8 @@ exports.getOG = function (options, callback) {
 	request(options, function (err, response, body) {
 		if (err) {
 			callback(err, null);
+		} else if ( response.statusCode !== 200 ) {
+			callback(new Error('Error from server'), null);
 		} else {
 			var $ = cheerio.load(body),
 				meta = $('meta'),

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -76,6 +76,10 @@ var options16 = {
 	'url': 'https://twitter.com/',
 }
 
+var options17 = {
+	'url': 'https://github.com/jshemas/notOpenGraphScraper'
+};
+
 // test videos
 var optionsYoutube = {
 		'url': 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
@@ -220,6 +224,14 @@ describe('GET OG', function () {
 	});
 	it('Invalid Call - url is a string of words', function (done) {
 		app(options14, function (err, result) {
+			expect(err).to.be(true);
+			expect(result.success).to.be(false);
+			expect(result.err).to.be('Page Not Found');
+			done();
+		});
+	});
+	it('Invalid Call - response code is 404', function (done) {
+		app(options17, function (err, result) {
 			expect(err).to.be(true);
 			expect(result.success).to.be(false);
 			expect(result.err).to.be('Page Not Found');


### PR DESCRIPTION
Right now library don’t report a error on `404` response from server.

I add extra check as it is described in `request` docs https://github.com/request/request#custom-http-headers