### PR TITLE
Take text only from head elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -494,12 +494,12 @@ exports.getOG = function (options, callback) {
 			// Check for 'only get open graph info'
 			if (!options.onlyGetOpenGraphInfo) {
 				// Get title tag if og title was not provided
-				if (!ogObject.ogTitle && $("title").text() && $("title").text().length > 0) {
-					ogObject.ogTitle = $("title").text();
+				if (!ogObject.ogTitle && $("head > title").text() && $("head > title").text().length > 0) {
+					ogObject.ogTitle = $("head > title").text();
 				}
 				// Get meta description tag if og description was not provided
-				if (!ogObject.ogDescription && $('meta[name="description"]').attr('content') && $('meta[name="description"]').attr('content').length > 0) {
-					ogObject.ogDescription = $('meta[name="description"]').attr('content');
+				if (!ogObject.ogDescription && $('head > meta[name="description"]').attr('content') && $('head > meta[name="description"]').attr('content').length > 0) {
+					ogObject.ogDescription = $('head > meta[name="description"]').attr('content');
 				}
 			}
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -279,7 +279,7 @@ describe('GET OG', function () {
 			expect(result.data.ogSiteName).to.be('YouTube');
 			expect(result.data.ogTitle).to.be('Rick Astley - Never Gonna Give You Up');
 			expect(result.data.ogUrl).to.be('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
-			expect(result.data.ogDescription).to.be('Music video by Rick Astley performing Never Gonna Give You Up. YouTube view counts pre-VEVO: 2,573,462 (C) 1987 PWL');
+			expect(result.data.ogDescription).to.be('Rick Astley - Never Gonna Give You Up (Official Music Video) Listen On Spotify: http://smarturl.it/AstleySpotify Buy On iTunes: http://smarturl.it/AstleyGHiT...');
 			expect(result.data.ogType).to.be('video');
 			expect(result.data.ogImage.url).to.be('https://i.ytimg.com/vi/dQw4w9WgXcQ/maxresdefault.jpg');
 			expect(result.data.ogVideo.url).to.be('https://www.youtube.com/embed/dQw4w9WgXcQ');


### PR DESCRIPTION
If `head` contains more than one title element in its children – we'll get all texts from them. For example here https://geekbrains.ru/posts/dress_the_code they have several svgs inside `head` and after parsing it we're getting

```"title":"Ð”Ñ€ÐµÑÑ-ÐºÐ¾Ð´ Ð² IT | GeekBrains - Ð¾Ð±Ñ€Ð°Ð·Ð¾Ð²Ð°Ñ‚ÐµÐ»ÑŒÐ½Ð°Ñ Ð¿Ð»Ð¾Ñ‰Ð°Ð´ÐºÐ° Ð´Ð»Ñ Ð¿Ñ€Ð¾Ð³Ñ€Ð°Ð¼Ð¼Ð¸ÑÑ‚Ð¾Ð²logo-textlogomainwebinarforumstudyingcoursestestsGBwebicons-08cartmessageslogoutloginlikegobacknoticearrow-downarrow-uparrow-leftarrow-rightlike-smallblogsettingshelpviewscommentstagsmoremenuinstagramvkvkontaktefacebookgooglegoogle_oauth2#double-arrow-leftavatarprobationmarkdown_logocog-smallcheckmore-iconcritical-noticecareercheckx-icnedit-icnemergency-helpicon-callbackicon-callback-hideicon-phone-whitesmile-icnunsmile-icnlike-miniviews-minicomments-minigroup-minipricecalendargroup-ocertificateclassroomrecruitrecruit-hoverplaygithublinkedinbitbuckethometwitterprojecttrashmarkrecruitwriterefuserefreshmark-filledicon-pulsestarsearchproject-rocketyoutubetelegramsendmore-horizontalcalendar-2listbookslaptopcaseprice-badge-corner"```

Same can happen with description.

After this fix from same link we're getting:
```"title":"Ð”Ñ€ÐµÑÑ-ÐºÐ¾Ð´ Ð² IT | GeekBrains - Ð¾Ð±Ñ€Ð°Ð·Ð¾Ð²Ð°Ñ‚ÐµÐ»ÑŒÐ½Ð°Ñ Ð¿Ð»Ð¾Ñ‰Ð°Ð´ÐºÐ° Ð´Ð»Ñ Ð¿Ñ€Ð¾Ð³Ñ€Ð°Ð¼Ð¼Ð¸ÑÑ‚Ð¾Ð²"```