### PR TITLE
Decode from any charset different from utf-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 	"dependencies": {
 		"request": "2.69.0",
 		"lodash": "4.2.1",
-		"cheerio": "0.20.0"
+		"cheerio": "0.20.0",
+		"charset": "1.0.0",
+		"iconv-lite": "0.4.13"
 	},
 	"devDependencies": {
 		"expect.js": "0.3.1",

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -108,6 +108,19 @@ var optionTwitter = {
 		'url': 'https://dev.twitter.com/'
 	};
 
+// test charset utf-8
+var optionCharset1 = {
+		'url': 'http://ogp.me/',
+		'withCharset': true
+	};
+
+// test charset windows-1251
+var optionCharset2 = {
+		'url': 'http://www.gazeta.ru/',
+		'encoding': null,
+		'withCharset': true
+	};
+
 describe('GET OG', function () {
 	this.timeout(10000); // should wait at least ten seconds before failing
 	it('Valid Call - ogp.me should return open graph data', function (done) {
@@ -350,6 +363,23 @@ describe('GET OG', function () {
 			expect(result.data.twitterImage.url).to.be('https://pbs.twimg.com/profile_images/2284174872/7df3h38zabcvjylnyfe3.png');
 			expect(result.data.twitterImage.width).to.be('500');
 			expect(result.data.twitterImage.height).to.be('500');
+			done();
+		});
+	});
+	it('Valid Call - Utf-8 charset - Should Return correct Open Graph Info + charset info', function (done) {
+		app(optionCharset1, function (err, result) {
+			expect(err).to.be(false);
+			expect(result.success).to.be(true);
+			expect(result.data.charset).to.be('utf8');
+			done();
+		});
+	});
+	it('Valid Call - windows-1251 charset - Should Return correct Open Graph Info + charset info', function (done) {
+		app(optionCharset2, function (err, result) {
+			expect(err).to.be(false);
+			expect(result.success).to.be(true);
+			expect(result.data.charset).to.be('windows-1251');
+			expect(result.data.ogTitle).to.be('Главные новости - Газета.Ru');
 			done();
 		});
 	});


### PR DESCRIPTION
If og info requested with encoding: null - as in `request` API – openGraphScraper will encode data properly. Otherwise, it will try to encode utf-8 and with win1251 case – it will produce unreadable data