### PR TITLE
Get charset from meta tag if response headers do not have charset

### DIFF
--- a/app.js
+++ b/app.js
@@ -437,8 +437,8 @@ exports.getOG = function (options, callback) {
 			callback(new Error('Error from server'), null);
 		} else {
 			if (options.encoding === null) {
-				if (charset(response.headers)) {
-					body = iconv.decode(body, charset(response.headers));
+				if (charset(response.headers, body)) {
+					body = iconv.decode(body, charset(response.headers, body));
 				} else {
 					body = body.toString();
 				}


### PR DESCRIPTION
Some urls don't have charset field in response header.
This PR makes charset module to try to detect charset from meta tag.