### PR TITLE
accept optional peekSize for determining charset

### DIFF
--- a/app.js
+++ b/app.js
@@ -430,6 +430,8 @@ exports.validateTimeout = function (inputTimeout) {
  * @param function callback
  */
 exports.getOG = function (options, callback) {
+	var peekSize = options.peekSize || 1024;
+	delete options.peekSize;
 	request(options, function (err, response, body) {
 		if (err) {
 			callback(err, null);
@@ -437,8 +439,8 @@ exports.getOG = function (options, callback) {
 			callback(new Error('Error from server'), null);
 		} else {
 			if (options.encoding === null) {
-				if (charset(response.headers, body, 1024)) {
-					body = iconv.decode(body, charset(response.headers, body));
+				if (charset(response.headers, body, peekSize)) {
+					body = iconv.decode(body, charset(response.headers, body, peekSize));
 				} else {
 					body = body.toString();
 				}
@@ -449,7 +451,7 @@ exports.getOG = function (options, callback) {
 				ogObject = {};
 
 			if (options.withCharset) {
-				ogObject.charset = charset(response.headers, body);
+				ogObject.charset = charset(response.headers, body, peekSize);
 			}
 
 			keys.forEach(function (key) {


### PR DESCRIPTION
an example would be
 http://www.jewish.ru/style/science/2016/09/news994335593.php

1024 is not enough for charset to decide the encoding in this case, so we need to customize peek size

additionally call to charset is consistently passed the peek size parameter.
