### PR TITLE
options for charset detection peek size and ogImage fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -430,6 +430,7 @@ exports.validateTimeout = function (inputTimeout) {
  * @param function callback
  */
 exports.getOG = function (options, callback) {
+	var peekSize = options.peekSize || 1024;
 	request(options, function (err, response, body) {
 		if (err) {
 			callback(err, null);
@@ -437,8 +438,8 @@ exports.getOG = function (options, callback) {
 			callback(new Error('Error from server'), null);
 		} else {
 			if (options.encoding === null) {
-				if (charset(response.headers, body, 1024)) {
-					body = iconv.decode(body, charset(response.headers, body));
+				if (charset(response.headers, body, peekSize)) {
+					body = iconv.decode(body, charset(response.headers, body, peekSize));
 				} else {
 					body = body.toString();
 				}
@@ -449,7 +450,7 @@ exports.getOG = function (options, callback) {
 				ogObject = {};
 
 			if (options.withCharset) {
-				ogObject.charset = charset(response.headers, body);
+				ogObject.charset = charset(response.headers, body, peekSize);
 			}
 
 			keys.forEach(function (key) {

--- a/app.js
+++ b/app.js
@@ -431,6 +431,7 @@ exports.validateTimeout = function (inputTimeout) {
  */
 exports.getOG = function (options, callback) {
 	var peekSize = options.peekSize || 1024;
+	var ogImageFallback = options.ogImageFallback === undefined ? true: options.ogImageFallback;
 	request(options, function (err, response, body) {
 		if (err) {
 			callback(err, null);
@@ -558,7 +559,7 @@ exports.getOG = function (options, callback) {
 					ogObject.ogDescription = $('head > meta[name="description"]').attr('content');
 				}
 				// Get first image as og:image if there is no og:image tag.
-				if (!ogObject.ogImage) {
+				if (!ogObject.ogImage && ogImageFallback) {
 					var supportedImageExts = ['jpg', 'jpeg', 'png'];
 					$('img').each(function (i, elem) {
 						if ($(elem).attr('src') && $(elem).attr('src').length > 0 && supportedImageExts.indexOf($(elem).attr('src').split('.').pop()) !== -1) {


### PR DESCRIPTION
- sometimes we would like to set a larger peek size for charset detection, e.g. http://www.jewish.ru/style/science/2016/09/news994335593.php this url needs a large peek size
this change adds a 'peekSize' parameter to option object
additionally the peek size should be added to all call sites

- ogImage fall back does not always make sense, for example scraping https://control.softlayer.com/ will fall back on the google app store icon
add a boolean 'ogImageFallback' parameter to option object