### PR TITLE
Add jschardet for the very legacy webpage

### DIFF
--- a/app.js
+++ b/app.js
@@ -445,9 +445,9 @@ exports.getOG = function (options, callback) {
 			callback(new Error('Error from server'), null);
 		} else {
 			if (options.encoding === null) {
-				var char = jschardet.detect(body);
-				if (char.encoding) {
-					body = iconv.decode(body, char.encoding);
+				var char = charset(response.headers, body, peekSize) || jschardet.detect(body).encoding;
+				if (char) {
+					body = iconv.decode(body, char);
 				} else {
 					body = body.toString();
 				}

--- a/app.js
+++ b/app.js
@@ -3,7 +3,8 @@ var request = require('request'),
 	charset = require('charset'),
 	iconv = require('iconv-lite'),
 	url = require('url'),
-	_ = require('lodash');
+	_ = require('lodash'),
+	jschardet = require('jschardet');
 
 module.exports = function (options, callback) {
 	return exports.info(options, callback);
@@ -444,8 +445,9 @@ exports.getOG = function (options, callback) {
 			callback(new Error('Error from server'), null);
 		} else {
 			if (options.encoding === null) {
-				if (charset(response.headers, body, peekSize)) {
-					body = iconv.decode(body, charset(response.headers, body, peekSize));
+				var char = jschardet.detect(body);
+				if (char.encoding) {
+					body = iconv.decode(body, char.encoding);
 				} else {
 					body = body.toString();
 				}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"charset": "1.0.0",
 		"cheerio": "0.22.0",
 		"iconv-lite": "0.4.13",
+		"jschardet": "1.4.1",
 		"lodash": "4.16.4",
 		"request": "2.75.0"
 	},


### PR DESCRIPTION
I fixed this because I found a problem with an old webpage with no charset specified.
example: http://www.f2.dion.ne.jp/~initialt/errdiffusion.html