### PR TITLE
Support node engines higher than v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "main": "app.js",
   "engines": {
-    "node": "6.x"
+    "node": ">=6.0"
   },
   "author": {
     "name": "Josh Shemas",


### PR DESCRIPTION
`yarn`, by default, will only install packages that match the current engine; so if you're running node 7.9 you cannot install this library.

To anyone hitting this issue, there's a simple **workaround**: `yarn add --ignore-engines open-graph-scraper`