### PR TITLE
Fix macys.com scraping

### DIFF
--- a/app.js
+++ b/app.js
@@ -353,6 +353,7 @@ exports.getInfo = function (options, callback) {
         options.gzip = false;
         options.protocol = url.parse(options.url).protocol;
       }
+      options.jar = request.jar();
       that.getOG(options, function (err, results, response) {
         if (results) {
           returnResult = {


### PR DESCRIPTION
Macy's pages return a redirect to themselves with some cookies set. Without sending the cookies, the same redirect response happens again. And again. And again.