### PR TITLE
Global cookie jar disabled by default

### DIFF
--- a/lib/openGraphScraper.js
+++ b/lib/openGraphScraper.js
@@ -53,7 +53,7 @@ var setOptionsAndReturnOpenGraphResults = function (options, callback) {
     }, options.headers);
     options.gzip = true;
     options.encoding = options.encoding || null;
-    options.jar = true;
+    options.jar = options.jar || false;
     options.followAllRedirects = options.followAllRedirects || true;
     options.maxRedirects = options.maxRedirects || 20;
 


### PR DESCRIPTION
suggest to turn off the "global cookie jar" feature by default,
as [requestjs](https://github.com/request/request/pull/587)  also set jar as optional