### PR TITLE
Add music:* OpenGraph fields

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -327,13 +327,13 @@ var fields = [
     fieldName: 'musicAlbum'
   },
   {
-    multiple: true,
+    multiple: false,
     property: 'music:album:disc',
     fieldName: 'musicAlbumDisc'
   },
   {
-    multiple: true,
-    property: 'music:album:Track',
+    multiple: false,
+    property: 'music:album:track',
     fieldName: 'musicAlbumTrack'
   }
 ];

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -285,6 +285,56 @@ var fields = [
     multiple: false,
     property: 'twitter:app:url:googleplay',
     fieldName: 'twitterAppUrlGooglePlay'
+  },
+  {
+    multiple: true,
+    property: 'music:song',
+    fieldName: 'musicSong'
+  },
+  {
+    multiple: true,
+    property: 'music:song:disc',
+    fieldName: 'musicSongDisc'
+  },
+  {
+    multiple: true,
+    property: 'music:song:track',
+    fieldName: 'musicSongTrack'
+  },
+  {
+    multiple: true,
+    property: 'music:musician',
+    fieldName: 'musicMusician'
+  },
+  {
+    multiple: false,
+    property: 'music:release_date',
+    fieldName: 'musicReleaseDate'
+  },
+  {
+    multiple: false,
+    property: 'music:duration',
+    fieldName: 'musicDuration'
+  },
+  {
+    multiple: true,
+    property: 'music:creator',
+    fieldName: 'musicCreator'
+  },
+  {
+    multiple: true,
+    property: 'music:album',
+    fieldName: 'musicAlbum'
+  },
+  {
+    multiple: true,
+    property: 'music:album:disc',
+    fieldName: 'musicAlbumDisc'
+  },
+  {
+    multiple: true,
+    property: 'music:album:Track',
+    fieldName: 'musicAlbumTrack'
   }
 ];
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -80,7 +80,14 @@ exports.mediaSetup = function (ogObject, options) {
 
   // Devare temporary fields
   fields.filter(function (item) {
-    return item.multiple;
+    return (
+      item.multiple && (
+        item.fieldName.startsWith('ogImage') ||
+        item.fieldName.startsWith('ogVideo') ||
+        item.fieldName.startsWith('twitter') ||
+        item.fieldName.startsWith('musicSong')
+      )
+    );
   }).forEach(function (item) {
     delete ogObject[item.fieldName];
   });

--- a/lib/media.js
+++ b/lib/media.js
@@ -66,6 +66,18 @@ exports.mediaSetup = function (ogObject, options) {
     ogObject.twitterPlayerStream)
     .map(mediaMapperTwitterPlayer).sort(mediaSorter);
 
+  /* Combine music:song url, track, disk
+    and sort in the right album order */
+  if (ogObject.musicSong || ogObject.musicSongTrack || ogObject.musicSongDisc) {
+    ogObject.musicSong = ogObject.musicSong ? ogObject.musicSong : [null];
+    ogObject.musicSongTrack = ogObject.musicSongTrack ? ogObject.musicSongTrack : [null];
+    ogObject.musicSongDisc = ogObject.musicSongDisc ? ogObject.musicSongDisc : [null];
+  }
+  var musicSongs = _.zip(ogObject.musicSong,
+    ogObject.musicSongTrack,
+    ogObject.musicSongDisc)
+    .map(mediaMapperMusicSong).sort(mediaSorterMusicSong);
+
   // Devare temporary fields
   fields.filter(function (item) {
     return item.multiple;
@@ -109,6 +121,15 @@ exports.mediaSetup = function (ogObject, options) {
     }
   }
 
+  // Select the best music:song
+  if (musicSongs.length) {
+    if (options.allMedia) {
+      ogObject.musicSong = musicSongs;
+    } else {
+      ogObject.musicSong = musicSongs[0];
+    }
+  }
+
   return ogObject;
 };
 
@@ -127,6 +148,14 @@ var mediaMapperTwitterPlayer = function (item) {
     width: item[1],
     height: item[2],
     stream: item[3]
+  };
+};
+
+var mediaMapperMusicSong = function (item) {
+  return {
+    url: item[0],
+    track: item[1],
+    disc: item[2]
   };
 };
 
@@ -155,4 +184,15 @@ var mediaSorter = function (a, b) {
     return 1;
   }
   return Math.max(b.width, b.height) - Math.max(a.width, a.height);
+};
+
+var mediaSorterMusicSong = function (a, b) {
+  if (!(a.track && b.track)) {
+    return 0;
+  } else if (a.disc > b.disc) {
+    return 1;
+  } else if (a.disc < b.disc) {
+    return -1;
+  }
+  return a.track - b.track;
 };

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -899,4 +899,71 @@ describe('GET OG', function () {
       done();
     });
   });
+  it('Valid Call - spotify album should return music:album and associated tags', function (done) {
+    app({
+      'url': 'https://open.spotify.com/album/5EBGCvO6upi3GNknMVe9x9'
+    }, function (error, result) {
+      console.log('error:', error);
+      console.log('result:', result);
+      expect(error).to.be(false);
+      expect(result.success).to.be(true);
+      expect(result.requestUrl).to.be('https://open.spotify.com/album/5EBGCvO6upi3GNknMVe9x9');
+      expect(result.data.ogType).to.be('music.album');
+      expect(result.data.musicMusician[0]).to.be('https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x');
+      expect(result.data.musicReleaseDate).to.be('2018-06-01');
+      expect(result.data.musicSong).to.be.an('object');
+      expect(result.data.musicSong.url).to.be.an('string');
+      expect(result).to.be.an('object');
+      done();
+    });
+  });
+  it('Valid Call - spotify artist should return music:musician', function (done) {
+    app({
+      'url': 'https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x'
+    }, function (error, result) {
+      console.log('error:', error);
+      console.log('result:', result);
+      expect(error).to.be(false);
+      expect(result.success).to.be(true);
+      expect(result.requestUrl).to.be('https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x');
+      expect(result.data.ogType).to.be('music.musician');
+      expect(result).to.be.an('object');
+      done();
+    });
+  });
+  it('Valid Call - spotify track should return music:song and associated tags', function (done) {
+    app({
+      'url': 'https://open.spotify.com/track/3p6fkbeZDIVqapfdgQe6fm'
+    }, function (error, result) {
+      console.log('error:', error);
+      console.log('result:', result);
+      expect(error).to.be(false);
+      expect(result.success).to.be(true);
+      expect(result.requestUrl).to.be('https://open.spotify.com/track/3p6fkbeZDIVqapfdgQe6fm');
+      expect(result.data.ogType).to.be('music.song');
+      expect(result.data.musicMusician[0]).to.be('https://open.spotify.com/artist/5K4W6rqBFWDnAN6FQUkS6x');
+      expect(result.data.musicDuration).to.be('196');
+      expect(result.data.musicReleaseDate).to.be('2016-06-10');
+      expect(result.data.musicAlbum[0]).to.be('https://open.spotify.com/album/4xM1pUHZp9HsuKNxyOQDR0');
+      expect(result.data.musicAlbumTrack).to.be('4');
+      expect(result).to.be.an('object');
+      done();
+    });
+  });
+  it('Valid Call - spotify playlist should return music:playlist and associated tags', function (done) {
+    app({
+      'url': 'https://open.spotify.com/user/mjaschmidt/playlist/4BSIiLTu7qzDZLDdkHaty9?si=9UCDOCPGQZKf9jkCBwDOMg'
+    }, function (error, result) {
+      console.log('error:', error);
+      console.log('result:', result);
+      expect(error).to.be(false);
+      expect(result.success).to.be(true);
+      expect(result.requestUrl).to.be('https://open.spotify.com/user/mjaschmidt/playlist/4BSIiLTu7qzDZLDdkHaty9?si=9UCDOCPGQZKf9jkCBwDOMg');
+      expect(result.data.ogType).to.be('music.playlist');
+      expect(result.data.musicSong).to.be.an('object');
+      expect(result.data.musicSong.url).to.be.an('string');
+      expect(result).to.be.an('object');
+      done();
+    });
+  });
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -573,7 +573,7 @@ describe('GET OG', function () {
       expect(error).to.be(false);
       expect(result.success).to.be(true);
       expect(result.requestUrl).to.be('https://www.namecheap.com/');
-      expect(result.data.ogTitle).to.be('\n\tDomain Names Starting at $0.48 - Namecheap.com\n');
+      expect(result.data.ogTitle).to.be('\n\tDomain Name Registration - Buy Domain Names from $0.48 - Namecheap\n');
       done();
     });
   });

--- a/tests/unit/media.spec.js
+++ b/tests/unit/media.spec.js
@@ -84,6 +84,55 @@ describe('media', function () {
       });
       done();
     });
+    it('media setup - has music:song', function (done) {
+      var ogMedia = media.mediaSetup({
+        ogTitle: 'test site',
+        ogType: 'website',
+        ogUrl: 'http://test.com/',
+        musicSong: [ 'http://test.com/songurl' ],
+        musicSongTrack: [ '1' ],
+        musicSongDisc: [ '1' ],
+        ogDescription: 'stuff'
+      }, {
+        url: 'http://test.com/'
+      });
+      expect(ogMedia.musicSong).to.eql({
+        url: 'http://test.com/songurl',
+        track: '1',
+        disc: '1'
+      });
+      done();
+    });
+    it('media setup - has multiple music:songs with allMedia set to true', function (done) {
+      var ogMedia = media.mediaSetup({
+        ogTitle: 'test site',
+        ogType: 'website',
+        ogUrl: 'http://test.com/',
+        musicSong: [ 'http://test.com/songurl', 'http://test.com/songurl3', 'http://test.com/songurl2' ],
+        musicSongTrack: [ '1', '2', '4' ],
+        musicSongDisc: [ '1', '2', '1' ],
+        ogDescription: 'stuff'
+      }, {
+        url: 'http://test.com/',
+        allMedia: true
+      });
+      expect(ogMedia.musicSong).to.eql([{
+        url: 'http://test.com/songurl',
+        track: '1',
+        disc: '1'
+      },
+      {
+        url: 'http://test.com/songurl2',
+        track: '4',
+        disc: '1'
+      },
+      {
+        url: 'http://test.com/songurl3',
+        track: '2',
+        disc: '2'
+      }]);
+      done();
+    });
     it('media setup - allMedia set to true', function (done) {
       var ogMedia = media.mediaSetup({
         ogTitle: 'test site',


### PR DESCRIPTION
I needed these to get data from Spotify. The fields are described here https://developers.facebook.com/docs/opengraph/music.

Changes in this pull request:

- updated the test in `index.spec.js` with namecheap where the page title had changed
- added `music:*` fields to `lib/fields.js`
- added `music:songs:*` to media types in `lib/media.js` so the array with url, track and album is zipped and sorted
- stopped fields with `multiple: true` that are not handled as media from being deleted in `lib/media.js` (such as music:musician, music:album)
- added tests for Spotify music:* tags and the music:songs:* array zipping and sorting

There's still one failing test for the Forbes redirect, which was failing when I cloned the project. I looked at it briefly but couldn't figure out what was going wrong on first sight.