### PR TITLE
Fix falsy options are not settable option parsing bug.

### DIFF
--- a/lib/openGraphScraper.js
+++ b/lib/openGraphScraper.js
@@ -128,16 +128,19 @@ const setOptionsAndReturnOpenGraphResults = async (options) => {
 
   options.url = validate.url;
   options.timeout = validate.timeout;
-  options.decompress = options.decompress || true;
-  options.peekSize = options.peekSize || 1024;
-  options.followRedirect = options.followRedirect || true;
-  options.maxRedirects = options.maxRedirects || 10;
-  options.retry = options.retry || 2;
-  options.onlyGetOpenGraphInfo = options.onlyGetOpenGraphInfo || false;
-  options.ogImageFallback = options.ogImageFallback || true;
-  options.allMedia = options.allMedia || false;
-  options.headers = options.headers || {};
-  options.responseType = options.responseType || 'buffer';
+  options = {
+    decompress: true,
+    peekSize: 1024,
+    followRedirect: true,
+    maxRedirects: 10,
+    retry: 2,
+    onlyGetOpenGraphInfo: false,
+    ogImageFallback: true,
+    allMedia: false,
+    headers: {},
+    responseType: 'buffer',
+    ...options,
+  };
 
   if (options.encoding === null) {
     // eslint-disable-next-line no-console

--- a/tests/integration/basic.spec.js
+++ b/tests/integration/basic.spec.js
@@ -2,7 +2,7 @@ const ogs = require('../../index');
 
 describe('basic', function () {
   // TODO: ogp.me has a bad cert at the moment, will need to update the test soon
-  it.skip('using callbacks should return valid data', function () {
+  it('using callbacks should return valid data', function () {
     return ogs({
       url: 'http://ogp.me/',
     }, function (error, result, response) {
@@ -27,7 +27,7 @@ describe('basic', function () {
     });
   });
   // TODO: ogp.me has a bad cert at the moment, will need to update the test soon
-  it.skip('using promises should return valid data', function () {
+  it('using promises should return valid data', function () {
     return ogs({ url: 'http://ogp.me/' })
       .then(function (data) {
         const { error, result, response } = data;

--- a/tests/integration/encoding.spec.js
+++ b/tests/integration/encoding.spec.js
@@ -122,7 +122,7 @@ describe('encoding', function () {
       });
     });
     // TODO: ogp.me has a bad cert at the moment, will need to update the test soon
-    it.skip('when charset is utf-8 - ogp', function () {
+    it('when charset is utf-8 - ogp', function () {
       return ogs({
         url: 'http://ogp.me/',
       }, function (error, result, response) {


### PR DESCRIPTION
Due to the way option were being processed, noticed you could never actually set say `ogImageFallback` to false - always uses the default `true`. This commit fixes this bug.