### PR TITLE
FEAT: Limit the download size of the fetched page

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Check the return for a ```success``` flag. If success is set to true, then the u
 | headers              | An object containing request headers. Useful for setting the user-agent    | {}            |          |
 | peekSize             | Sets the peekSize for the request                                          | 1024          |          |
 | agent                | Used for Proxies, Look below for notes on how to use.                      | null          |          |
+| downloadLimit        | Maximum size of the content downloaded from the server, in bytes           | 1000000 (1MB) |          |
 | urlValidatorSettings | Sets the options used by validator.js for testing the URL                  | [Here](https://github.com/jshemas/openGraphScraper/blob/master/lib/openGraphScraper.js#L21-L36)          |          |
 
 Note: `open-graph-scraper` uses [got](https://github.com/sindresorhus/got) for requests and most of [got's options](https://github.com/sindresorhus/got#options) should work as `open-graph-scraper` options.

--- a/lib/openGraphScraper.js
+++ b/lib/openGraphScraper.js
@@ -53,6 +53,7 @@ const setOptionsAndReturnOpenGraphResults = async (options) => {
     headers: {},
     responseType: 'buffer',
     agent: null,
+    downloadLimit: 1e6,
     ...options,
   };
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 const chardet = require('chardet');
 const iconv = require('iconv-lite');
-const request = require('got');
+const got = require('got');
 
 const charset = require('./charset');
 const { extractMetaTags } = require('./extract');
@@ -13,7 +13,46 @@ exports.requestAndResultsFormatter = async (options) => {
   const requestUrl = options.url;
   delete options.url; // setting options.url messes with got
 
-  return request.get(requestUrl, options)
+  // limit the size of the content we fetch when performing the request
+  // from https://github.com/sindresorhus/got/blob/main/documentation/examples/advanced-creation.js#L40
+  const gotClient = got.extend({
+    handlers: [
+      (requestOptions, next) => {
+        const { downloadLimit, uploadLimit } = requestOptions;
+        const promiseOrStream = next(requestOptions);
+
+        // A destroy function that supports both promises and streams
+        const destroy = (message) => {
+          if (requestOptions.isStream) {
+            promiseOrStream.destroy(new Error(message));
+            return;
+          }
+
+          promiseOrStream.cancel(message);
+        };
+
+        if (typeof downloadLimit === 'number') {
+          promiseOrStream.on('downloadProgress', (progress) => {
+            if (progress.transferred > downloadLimit && progress.percent !== 1) {
+              destroy(`Exceeded the download limit of ${downloadLimit} bytes`);
+            }
+          });
+        }
+
+        if (typeof uploadLimit === 'number') {
+          promiseOrStream.on('uploadProgress', (progress) => {
+            if (progress.transferred > uploadLimit && progress.percent !== 1) {
+              destroy(`Exceeded the upload limit of ${uploadLimit} bytes`);
+            }
+          });
+        }
+
+        return promiseOrStream;
+      },
+    ],
+  });
+
+  return gotClient.get(requestUrl, options)
     .then((response) => {
       options.url = requestUrl;
       let formatBody = response.body;


### PR DESCRIPTION
The request timeout would limit damages if we're passed the URL
of a large file but we don't want to run out of memory if too much
content gets transferred.

Test case:
```
const a = require('open-graph-scraper');
a({url: 'https://releases.ubuntu.com/20.04.3/ubuntu-20.04.3-desktop-amd64.iso', timeout: 60000}).then(r => b=r, console.log)
```
Memory use for Node.JS will reach something like a Gigabyte. I think it's OK to avoid fetching more than 1MB of content.

I'm not sure about testing. We could create a local server throwing an error if too much content is consumed?