### PR TITLE
TS export run as a Promise

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -50,11 +50,11 @@ declare function run(options: {
     peekSize?: number;
     downloadLimit?: number;
     urlValidatorSettings?: validatorSettings;
-}): {
+}): Promise<{
     error: boolean;
     result: object;
     response: object;
-};
+}>;
 declare namespace run {
     export { customMetaTags, validatorSettings };
 }


### PR DESCRIPTION
Remove the warning :
`'await' has no effect on the type of this expression. ts(80007)`