### PR TITLE
Solve the problem of not specifying the html option in TypeScript #187

### DIFF
--- a/dist/lib/openGraphScraper.js
+++ b/dist/lib/openGraphScraper.js
@@ -15,9 +15,9 @@ const utils_1 = require("./utils");
  */
 async function setOptionsAndReturnOpenGraphResults(ogsOptions) {
     const { options } = (0, utils_1.optionSetup)(ogsOptions);
+    if (options.html && options.url)
+        throw new Error('Must specify either `url` or `html`, not both');
     if (options.html) {
-        if (options.url)
-            throw new Error('Must specify either `url` or `html`, not both');
         const ogObject = (0, extract_1.default)(options.html, options);
         ogObject.success = true;
         return { ogObject, response: { body: options.html }, html: options.html };

--- a/dist/lib/types.d.ts
+++ b/dist/lib/types.d.ts
@@ -18,7 +18,7 @@ export type OpenGraphScraperOptions = {
     html?: string;
     onlyGetOpenGraphInfo?: boolean;
     timeout?: number;
-    url: string;
+    url?: string;
     urlValidatorSettings?: ValidatorSettings;
 };
 /**

--- a/lib/openGraphScraper.ts
+++ b/lib/openGraphScraper.ts
@@ -18,8 +18,9 @@ import type { OpenGraphScraperOptions } from './types';
 export default async function setOptionsAndReturnOpenGraphResults(ogsOptions: OpenGraphScraperOptions) {
   const { options } = optionSetup(ogsOptions);
 
+  if (options.html && options.url) throw new Error('Must specify either `url` or `html`, not both');
+
   if (options.html) {
-    if (options.url) throw new Error('Must specify either `url` or `html`, not both');
     const ogObject = extractMetaTags(options.html, options);
     ogObject.success = true;
     return { ogObject, response: { body: options.html }, html: options.html };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,7 @@ export type OpenGraphScraperOptions = {
   html?: string;
   onlyGetOpenGraphInfo?: boolean;
   timeout?: number;
-  url: string;
+  url?: string;
   urlValidatorSettings?: ValidatorSettings;
 };
 


### PR DESCRIPTION
This Pull Request (PR) is intended to resolve a bug identified in Issue #187.

## Main Changes

The following updates have been made:

- Modified the 'url' property in 'OpenGraphScraperOptions' to be an Optional Property.
- Added an error message to be thrown earlier when both 'html' and 'url' are provided.

I could not pass all tests in my environment, probably because it depends on the location where the test is executed.
I would appreciate it if you could run the test in your environment just to be sure.

The failed tests are as follows

````
107 passing (31s)
  6 pending
  3 failing

  1) basic
       vimeo.com should return open graph data:.

      AssertionError: expected [ { height: '720', ...(3) } ] to deeply equal [ { ...(4) }
      + expected - actual

       [
         {
           "height": "720"
      - "type": "image/jpeg"
      + "type": "image/jpeg"
           "url": "https://i.vimeocdn.com/video/659221704-68d52ff1744d1c12605d1743d3ea6b031937d002d9373e5f6111a6aef986f3e5-d"
           "width": "1280"
         }
       ]
      
      at /home/username/workspace/openGraphScraper/tests/integration/basic.spec.js:183:36
      at processTicksAndRejections (node:internal/process/task_queues:95:5)

  2) basic
       facebook - testing cors mode - header origin should default to url:.

      AssertionError: expected 'ja_JP' to deeply equal 'en_US'
      + expected - actual

      -ja_JP
      +en_US
      
      at /home/username/workspace/openGraphScraper/tests/integration/basic.spec.js:290:39
      at processTicksAndRejections (node:internal/process/task_queues:95:5)

  3) video
       Test Youtube Video - Should Return correct Open Graph Info:.
     AssertionError: expected 'ja-JP' to be one of [ 'en', 'en-US', 'nl-NL'].
      at /home/username/workspace/openGraphScraper/tests/integration/video.spec.js:21:37
      at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

