### PR TITLE
fix: JSON parsing fails when Youtube escape '&' to '\x26' (#234)

### DIFF
--- a/lib/extract.ts
+++ b/lib/extract.ts
@@ -3,6 +3,7 @@ import { load } from 'cheerio';
 import fallback from './fallback';
 import fields from './fields';
 import mediaSetup from './media';
+import { unescapeScriptText } from './utils';
 
 import type { OgObjectInteral, OpenGraphScraperOptions } from './types';
 
@@ -94,8 +95,9 @@ export default function extractMetaTags(body: string, options: OpenGraphScraperO
     $('script').each((index, script) => {
       if (script.attribs.type && script.attribs.type === 'application/ld+json') {
         if (!ogObject.jsonLD) ogObject.jsonLD = [];
-        const scriptText = $(script).text();
+        let scriptText = $(script).text();
         if (scriptText) {
+          scriptText = unescapeScriptText(scriptText);
           ogObject.jsonLD.push(JSON.parse(scriptText));
         }
       }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -174,5 +174,11 @@ export function isCustomMetaTagsValid(customMetaTags: CustomMetaTags[]): boolean
  */
 export function unescapeScriptText(scriptText: string) {
   // https://stackoverflow.com/a/34056693
-  return scriptText.replace(/\\x([0-9a-f]{2})/ig, (_, pair) => String.fromCharCode(parseInt(pair, 16)));
+  return scriptText.replace(/\\x([0-9a-f]{2})/ig, (_, pair) => {
+    const charCode = parseInt(pair, 16);
+    if (charCode === 34) {
+      return '\\"';
+    }
+    return String.fromCharCode(charCode);
+  });
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -146,3 +146,33 @@ export function isCustomMetaTagsValid(customMetaTags: CustomMetaTags[]): boolean
 
   return result;
 }
+
+/**
+ * Unescape script text.
+ *
+ * Certain websites escape script text within script tags, which can
+ * interfere with `JSON.parse()`. Therefore, we need to unescape it.
+ *
+ * Known good escape sequences:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape#uhhhh
+ *
+ * ```js
+ * JSON.parse('"\\u2611"'); // '☑'
+ * ```
+ *
+ * Known bad escape sequences:
+ *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape#xhh
+ *
+ * ```js
+ * JSON.parse('"\\x26"'); // '&'
+ * ```
+ *
+ * @param {string} scriptText - the text of the script tag
+ * @returns {string} unescaped script text
+ */
+export function unescapeScriptText(scriptText: string) {
+  // https://stackoverflow.com/a/34056693
+  return scriptText.replace(/\\x([0-9a-f]{2})/ig, (_, pair) => String.fromCharCode(parseInt(pair, 16)));
+}

--- a/tests/integration/video.spec.ts
+++ b/tests/integration/video.spec.ts
@@ -110,6 +110,113 @@ describe('video', function () {
     });
   });
 
+  it('Test Youtube Video with bad escape sequence - Should Return correct Open Graph Info', function () {
+    return ogs({ url: 'https://www.youtube.com/watch?v=nFbKMg4E3JM' }).then(function ({ error, result, response }) {
+      console.log('error:', error);
+      console.log('result:', result);
+      expect(error).to.be.eql(false);
+      expect(result.alAndroidAppName).to.be.eql('YouTube');
+      expect(result.alAndroidPackage).to.be.eql('com.google.android.youtube');
+      expect(result.alAndroidUrl).to.be.eql('vnd.youtube://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks');
+      expect(result.alIosAppName).to.be.eql('YouTube');
+      expect(result.alIosAppStoreId).to.be.eql('544007664');
+      expect(result.alIosUrl).to.be.eql('vnd.youtube://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks');
+      expect(result.alWebUrl).to.be.oneOf(['https://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks', 'http://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks']);
+      expect(result.ogSiteName).to.be.eql('YouTube');
+      expect(result.ogUrl).to.be.eql('https://www.youtube.com/watch?v=nFbKMg4E3JM');
+      expect(result.ogTitle).to.be.eql('Force Class 10 in One Shot (Full Chapter) | ICSE 10 Physics Chapter 1 - Abhishek Sir |Vedantu 9 & 10');
+      expect(result.ogDescription).to.be.an('string').and.to.not.be.empty;
+      expect(result.ogType).to.be.eql('video.other');
+      expect(result.ogLocale).to.be.oneOf(['en', 'en-US', 'nl-NL']);
+      expect(result.twitterCard).to.be.eql('player');
+      expect(result.twitterSite).to.be.eql('@youtube');
+      expect(result.twitterTitle).to.be.eql('Force Class 10 in One Shot (Full Chapter) | ICSE 10 Physics Chapter 1 - Abhishek Sir |Vedantu 9 & 10');
+      expect(result.twitterDescription).to.be.an('string').and.to.not.be.empty;
+      expect(result.twitterAppNameiPhone).to.be.eql('YouTube');
+      expect(result.twitterAppIdiPhone).to.be.eql('544007664');
+      expect(result.twitterAppNameiPad).to.be.eql('YouTube');
+      expect(result.twitterAppIdiPad).to.be.eql('544007664');
+      expect(result.twitterUrl).to.be.eql('https://www.youtube.com/watch?v=nFbKMg4E3JM');
+      expect(result.ogDate).to.be.eql('2021-06-11T09:14:37-07:00');
+      expect(result.twitterAppUrliPhone).to.be.eql('vnd.youtube://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks');
+      expect(result.twitterAppUrliPad).to.be.eql('vnd.youtube://www.youtube.com/watch?v=nFbKMg4E3JM&feature=applinks');
+      expect(result.twitterAppNameGooglePlay).to.be.eql('YouTube');
+      expect(result.twitterAppIdGooglePlay).to.be.eql('com.google.android.youtube');
+      expect(result.twitterAppUrlGooglePlay).to.be.eql('https://www.youtube.com/watch?v=nFbKMg4E3JM');
+      expect(result.ogImage).to.be.eql([{
+        url: 'https://i.ytimg.com/vi/nFbKMg4E3JM/maxresdefault.jpg',
+        width: '1280',
+        height: '720',
+        type: 'jpg',
+      }]);
+      expect(result.ogVideo).to.be.eql([{
+        url: 'https://www.youtube.com/embed/nFbKMg4E3JM',
+        width: '1280',
+        height: '720',
+        type: 'text/html',
+      }]);
+      expect(result.twitterImage).to.be.eql([{
+        url: 'https://i.ytimg.com/vi/nFbKMg4E3JM/maxresdefault.jpg',
+      }]);
+      expect(result.twitterPlayer).to.be.eql([{
+        url: 'https://www.youtube.com/embed/nFbKMg4E3JM',
+        width: '1280',
+        height: '720',
+      }]);
+      expect(result.ogVideoTag).to.be.eql('vedantu');
+      expect(result.ogVideoSecureURL).to.be.eql('https://www.youtube.com/embed/nFbKMg4E3JM');
+      expect(result.requestUrl).to.be.eql('https://www.youtube.com/watch?v=nFbKMg4E3JM');
+      expect(result.charset).to.be.eql('UTF-8');
+      expect(result.success).to.be.eql(true);
+      expect(result.fbAppId).to.be.eql('87741124305');
+      expect(result.jsonLD).to.be.an('array').and.to.not.be.empty;
+      if (result.ogDate === undefined) result.ogDate = 'hack because sometimes this does not come back for some reason';
+      expect(result).to.have.all.keys(
+        'favicon',
+        'fbAppId',
+        'jsonLD',
+        'alAndroidAppName',
+        'alAndroidPackage',
+        'alAndroidUrl',
+        'alIosAppName',
+        'alIosAppStoreId',
+        'alIosUrl',
+        'alWebUrl',
+        'ogDate',
+        'ogDescription',
+        'ogImage',
+        'ogLocale',
+        'ogSiteName',
+        'ogTitle',
+        'ogType',
+        'ogUrl',
+        'ogVideo',
+        'ogVideoTag',
+        'ogVideoSecureURL',
+        'requestUrl',
+        'success',
+        'charset',
+        'twitterAppIdGooglePlay',
+        'twitterAppIdiPad',
+        'twitterAppIdiPhone',
+        'twitterAppNameGooglePlay',
+        'twitterAppNameiPad',
+        'twitterAppNameiPhone',
+        'twitterAppUrlGooglePlay',
+        'twitterAppUrliPad',
+        'twitterAppUrliPhone',
+        'twitterCard',
+        'twitterDescription',
+        'twitterImage',
+        'twitterPlayer',
+        'twitterSite',
+        'twitterTitle',
+        'twitterUrl',
+      );
+      expect(response).to.be.an('Response');
+    });
+  });
+
   it('Test Twitch.tv Video - Should Return correct Open Graph Info', function () {
     return ogs({ url: 'https://jshemas.github.io/openGraphScraperPages/twitch.html' }).then(function ({ error, result, response }) {
       console.log('error:', error);

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   isThisANonHTMLUrl,
   optionSetup,
   removeNestedUndefinedValues,
+  unescapeScriptText,
   validateAndFormatURL,
 } from '../../lib/utils';
 
@@ -303,6 +304,19 @@ describe('utils', function () {
       // @ts-ignore
       const response = isCustomMetaTagsValid(['foo', 'bar']);
       expect(response).to.eql(false);
+    });
+  });
+
+  describe('unescapeScriptText', function () {
+    it('is needed because `JSON.parse()` is not able to parse string with \\xHH', function () {
+      expect(JSON.parse('"\\u2611"')).to.eql('☑');
+      expect(() => {
+        JSON.parse('"\\x26"');
+      }).to.throw(SyntaxError);
+    });
+
+    it('should unescape script text', function () {
+      expect(unescapeScriptText('"\\x26"')).to.eql('"&"');
     });
   });
 });

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -316,6 +316,7 @@ describe('utils', function () {
     });
 
     it('should unescape script text', function () {
+      expect(unescapeScriptText('"\\x27"')).to.eql('"\'"');
       expect(unescapeScriptText('"\\x26"')).to.eql('"&"');
       expect(unescapeScriptText('"\\x22"')).to.eql('"\\""');
     });

--- a/tests/unit/utils.spec.ts
+++ b/tests/unit/utils.spec.ts
@@ -317,6 +317,7 @@ describe('utils', function () {
 
     it('should unescape script text', function () {
       expect(unescapeScriptText('"\\x26"')).to.eql('"&"');
+      expect(unescapeScriptText('"\\x22"')).to.eql('"\\""');
     });
   });
 });


### PR DESCRIPTION
Fixes #234

When a channel have `&` character like https://www.youtube.com/@VedantuClass9_10_11, in their LD+JSON, Youtube might escape it to `\x26`:


![CleanShot 2024-07-22 at 20 44 55@2x](https://github.com/user-attachments/assets/ddb175f0-2430-493b-b945-49438c2f0426)

Some how the `\` got escaped into `\\` and then passed into `JSON.parse()`, which cause it to failed. Something like this.

```js
JSON.parse('{"@context": "http://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "item": {"@id": "https:\/\/www.youtube.com\/channel\/UCMY7ZvLB6-DnuSis_2s37_A", "name": "Vedantu 9,10 \\x2611"}}]}')
```

The behavior is not really consistent as `\\u2611` would not have any issue. So it seems that `JSON.parse()` can escape `\uHHHH` correctly but cannot escape `\xHH` properly.

I have write in the test for these inconsistency and introduce a preprocessor to unescape the script text.

Do note that this is not 100% fool proof, for example if anyone escape `"` with `\\x22`, then the unescape code will be malformed. I have instead replaced it with escaped double quote (`\\"`).

In case I did not cover enough cases, more unit test can be covered. So far these changes does not break any tests.