### PR TITLE
Always use default settings for headers

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -52,7 +52,7 @@ export default async function requestAndResultsFormatter(options: OpenGraphScrap
       options.url ?? '',
       {
         signal: AbortSignal.timeout((options.timeout ?? 10) * 1000),
-        headers: { Origin: options.url ?? '', Accept: 'text/html' },
+        headers: { Origin: options.url ?? '', Accept: 'text/html', ...options.fetchOptions?.headers },
         ...options.fetchOptions,
       },
     );

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -52,8 +52,8 @@ export default async function requestAndResultsFormatter(options: OpenGraphScrap
       options.url ?? '',
       {
         signal: AbortSignal.timeout((options.timeout ?? 10) * 1000),
-        headers: { Origin: options.url ?? '', Accept: 'text/html', ...options.fetchOptions?.headers },
         ...options.fetchOptions,
+        headers: { Origin: options.url ?? '', Accept: 'text/html', ...options.fetchOptions?.headers },
       },
     );
 


### PR DESCRIPTION
It seems that some websites require the `Origin` header to be included. For example, https://dev.epicgames.com/documentation/ja-jp/unreal-engine/volume-actors-in-unreal-engine and others.

In the current specification of this library, when customizing `fetchOptions.headers`, the default header values for [Origin and Accept](https://github.com/jshemas/openGraphScraper/blob/master/lib/request.ts#L55) are lost. With this change, the default `Origin` header will remain effective even when customizing headers.

The following is a sample code that fails:

```ts
import ogs from "open-graph-scraper";

const main = async () => {
  const url =
    "https://dev.epicgames.com/documentation/ja-jp/unreal-engine/volume-actors-in-unreal-engine";
  const { result } = await ogs({
    url,
    fetchOptions: {
      headers: {
        "user-agent": "Twitterbot",
      },
    },
  });
  console.log(result);
};

main();

// => UnhandledPromiseRejection
```

The following is a sample code that succeeds:

```diff
import ogs from "open-graph-scraper";

const main = async () => {
  const url =
    "https://dev.epicgames.com/documentation/ja-jp/unreal-engine/volume-actors-in-unreal-engine";
  const { result } = await ogs({
    url,
    fetchOptions: {
      headers: {
        "user-agent": "Twitterbot",
+       Origin: url,
      },
    },
  });
  console.log(result);
};

main();

// => { success: true, ... }
```

We, as users of the library, can resolve this issue by explicitly setting the `Origin` header. However, it can sometimes be difficult to identify the cause of the problem. By including the `Origin` header by default, we can reduce potential pitfalls for developers.

Thank you for this great package.