### PR TITLE
add encodeURIComponent function in requestAndResultsFormatter

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -44,12 +44,25 @@ function getCharset(body: string, buffer: ArrayBuffer, $: CheerioAPI) {
  * @return {object} formatted request body and response
  *
  */
+
+function shouldEncode(value: string) {
+  const regex = /[^\x00-\x7F]/;
+  return regex.test(value);
+}
+
 export default async function requestAndResultsFormatter(options: OpenGraphScraperOptions) {
   let body;
   let response;
+
+  let url = options.url ?? ''
+
+  if (shouldEncode(url)) {
+    url = encodeURIComponent(url)
+  } 
+
   try {
     response = await fetch(
-      options.url ?? '',
+      url ?? '',
       {
         signal: AbortSignal.timeout((options.timeout ?? 10) * 1000),
         ...options.fetchOptions,


### PR DESCRIPTION
[https://github.com/jshemas/openGraphScraper/issues/248](Issue)
I think I fixed this issue. 

```
function shouldEncode(value: string) {
  const regex = /[^\x00-\x7F]/;
  return regex.test(value);
}

export default async function requestAndResultsFormatter(options: OpenGraphScraperOptions) {
  let body;
  let response;

  + let url = options.url ?? ''

  + if (shouldEncode(url)) {
  + url = encodeURIComponent(url)
  + } 

  try {
    response = await fetch(
      url ?? '',
      {
        signal: AbortSignal.timeout((options.timeout ?? 10) * 1000),
        ...options.fetchOptions,
        headers: { Origin: options.url ?? '', Accept: 'text/html', ...options.fetchOptions?.headers },
      },
    );
...
```

Please let me know if there are any missing fixes!