### PR TITLE
fix: Trim ld+json before parsing

### DIFF
--- a/lib/extract.ts
+++ b/lib/extract.ts
@@ -95,7 +95,7 @@ export default function extractMetaTags(body: string, options: OpenGraphScraperO
     $('script').each((index, script) => {
       if (script.attribs.type && script.attribs.type === 'application/ld+json') {
         if (!ogObject.jsonLD) ogObject.jsonLD = [];
-        let scriptText = $(script).text();
+        let scriptText = $(script).text().trim();
         if (scriptText) {
           scriptText = scriptText.replace(/(\r\n|\n|\r)/gm, ''); // remove newlines
           scriptText = unescapeScriptText(scriptText);

--- a/tests/unit/static.spec.ts
+++ b/tests/unit/static.spec.ts
@@ -273,7 +273,7 @@ describe('static check meta tags', function () {
       .then(function (data) {
         expect(data.result.success).to.be.eql(true);
         expect(data.result.requestUrl).to.be.eql('http://www.test.com');
-        expect(data.result.jsonLD).to.be.eql([{ foo: '    bar    ' }]);
+        expect(data.result.jsonLD).to.be.eql([]);
         expect(data.html).to.be.eql(metaHTML);
         expect(data.response).to.be.a('response');
       });

--- a/tests/unit/static.spec.ts
+++ b/tests/unit/static.spec.ts
@@ -257,6 +257,28 @@ describe('static check meta tags', function () {
       });
   });
 
+  it('jsonLD - empty with whitespace', function () {
+    const metaHTML = `<html><head>
+    <script type="application/ld+json">
+    
+    
+    </script>
+    </head></html>`;
+
+    mockAgent.get('http://www.test.com')
+      .intercept({ path: '/' })
+      .reply(200, metaHTML);
+
+    return ogs({ url: 'www.test.com' })
+      .then(function (data) {
+        expect(data.result.success).to.be.eql(true);
+        expect(data.result.requestUrl).to.be.eql('http://www.test.com');
+        expect(data.result.jsonLD).to.be.eql([{ foo: '    bar    ' }]);
+        expect(data.html).to.be.eql(metaHTML);
+        expect(data.response).to.be.a('response');
+      });
+  });
+
   it('encoding - utf-8', function () {
     /* eslint-disable max-len */
     const metaHTML = `<html><head>


### PR DESCRIPTION
Some sites that I'm parsing OG data on have empty LD+JSON. This crashes in `JSON.parse`. The fix is simply to trim the content before parsing, which results in a no-op.