### PR TITLE
fix: normalize content-type header check for case insensitivity

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -72,7 +72,8 @@ export default async function requestAndResultsFormatter(options: OpenGraphScrap
       body = decode(Buffer.from(bodyArrayBuffer), charset);
     }
 
-    if (response?.headers?.get('content-type') && !response.headers.get('content-type')?.includes('text/')) {
+    const contentType = response?.headers?.get('content-type')?.toLowerCase();
+    if (contentType && !contentType.includes('text/')) {
       throw new Error('Page must return a header content-type with text/');
     }
     if (response?.status && (response.status.toString().startsWith('4') || response.status.toString().startsWith('5'))) {

--- a/tests/unit/openGraphScraper.spec.ts
+++ b/tests/unit/openGraphScraper.spec.ts
@@ -709,6 +709,22 @@ describe('return ogs', function () {
         });
     });
 
+    it('should handle case-insensitive Content-Type headers', function () {
+      mockAgent.get('http://www.test.com')
+        .intercept({ path: '/' })
+        .reply(200, basicHTML, { headers: { 'Content-Type': 'Text/html; charset=utf-8' } });
+
+      return ogs({ url: 'http://www.test.com' })
+        .then(function (data) {
+          expect(data.result.success).to.be.eql(true);
+          expect(data.error).to.be.eql(false);
+          expect(data.result.ogTitle).to.be.eql('test page');
+          expect(data.result.requestUrl).to.be.eql('http://www.test.com');
+          expect(data.html).to.be.eql(basicHTML);
+          expect(data.response).to.be.a('response');
+        });
+    });
+
     it('when trying to hit a non html pages based on content-type', function () {
       mockAgent.get('http://www.test.com')
         .intercept({ path: '/' })


### PR DESCRIPTION
### Summary
This PR addresses an issue where the `content-type` header check was case-sensitive, causing valid `Content-Type` values like `Text/html` to be rejected. The solution normalizes the `content-type` header using `.toLowerCase()` to ensure case-insensitive checks.

### Reproduction Steps

1. Make a request to a URL with a Content-Type header of Text/html; charset=utf-8.
2. The scraper incorrectly throws an error:
```yaml
Page must return a header content-type with text/
```

3. Expected behavior: The scraper should successfully process URLs with case-insensitive `Content-Type` headers.

### Changes Made

- Updated the `content-type` check in the scraper logic to use `toLowerCase()`.
- Added a new test case for case-insensitive Content-Type values:
  - `Content-Type: Text/html` now works as expected.
- Verified existing tests to ensure no regressions.
